### PR TITLE
check for definitions existence

### DIFF
--- a/src/views/Home/index.js
+++ b/src/views/Home/index.js
@@ -254,7 +254,7 @@ class HomeView extends Component {
         >
           {views.map(
             ({ type, hash }, index) =>
-              this.props.definitions[type] && (
+              this.props.definitions && this.props.definitions[type] && (
                 <div key={index}>
                   <DataView
                     definitions={definitions}


### PR DESCRIPTION
this fixes the crash when you directly access an entry via URL
i.e. https://data.destinysets.com/i/Collectible:1434150394

maybe this should be addressed upstream of the edited line? the line hasn't been changed, so i assume definitions are not being sent and used to be. but the page works fine with this check added so i assume definitions weren't actually needed in the loop index where it actually crashes 