### PR TITLE
Add locale patching support

### DIFF
--- a/src/store/app.js
+++ b/src/store/app.js
@@ -8,6 +8,14 @@ const INITIAL_STATE = {
   collectedItems: {}
 };
 
+const LANGUAGE_PATCHES = [
+  {
+    "identifier": "zh-chs",
+    "isDefault": false,
+    "displayName": "简体中文"
+  }
+];
+
 const TOGGLE_COLLECT_MODE = "Toggle collect mode";
 const TOGGLE_FILTER_DRAWER = "Toggle filter drawer";
 const ADD_COLLECTED_ITEM = "Add collected item";
@@ -90,6 +98,13 @@ export const setActiveLanguage = makePayloadAction(SET_ACTIVE_LANGUAGE);
 export const fetchBungieSettings = () => dispatch => {
   getDestiny("/Platform/Settings/").then(settings => {
     console.log("settings:", settings);
+    // Patch language list
+    const locales = settings.userContentLocales;
+    const localeIds = locales.map(language => language.identifier);
+    // De-duplicate patches
+    const localePatches = LANGUAGE_PATCHES.filter(patch => localeIds.indexOf(patch.identifier) < 0);
+    settings.userContentLocales = locales.concat(localePatches);
+    console.log("locales: fetched " + locales.length + ", patched " + localePatches.length);
     dispatch({
       type: SET_BUNGIE_SETTINGS,
       payload: settings


### PR DESCRIPTION
Dynamically patches the list of `userContentLocales` to add missing languages (at this moment, only `zh-chs`.) I'm not fluent in JavaScript - feel free to modify :)

Note that searching in Asian languages is still broken because `normalize-text` library filters out any Asian characters, in this line:
https://github.com/joshhunt/destinyDataExplorer/blob/d9d8d8be05916eba13739b0a890aaf5faaf4e322/src/lib/search/index.js#L18

For example, these two expressions both return empty:
```js
_normalizeText("土卫六"); // zh-chs
_normalizeText("紺碧の閃き"); // ja
```